### PR TITLE
Support for AppEngine classic

### DIFF
--- a/isatty_appengine.go
+++ b/isatty_appengine.go
@@ -1,0 +1,9 @@
+// +build appengine
+
+package isatty
+
+// IsTerminal returns true if the file descriptor is terminal which
+// is always false on on appengine classic which is a sandboxed PaaS.
+func IsTerminal(fd uintptr) bool {
+	return false
+}

--- a/isatty_bsd.go
+++ b/isatty_bsd.go
@@ -1,4 +1,5 @@
 // +build darwin freebsd openbsd netbsd
+// +build !appengine
 
 package isatty
 

--- a/isatty_linux.go
+++ b/isatty_linux.go
@@ -1,4 +1,5 @@
 // +build linux
+// +build !appengine
 
 package isatty
 

--- a/isatty_solaris.go
+++ b/isatty_solaris.go
@@ -1,4 +1,5 @@
 // +build solaris
+// +build !appengine
 
 package isatty
 

--- a/isatty_windows.go
+++ b/isatty_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+// +build !appengine
 
 package isatty
 


### PR DESCRIPTION
Build tags and stubbed out function to support Google AppEngine Classic

Prevents deployment errors if any app ultimately has any dependency on this one (e.g. https://github.com/labstack/echo).

AppEngine Classic doesn't support terminal and the sandbox blocks packages using "unsafe".