### PR TITLE
Add dragonfly to bsd build

### DIFF
--- a/isatty_bsd.go
+++ b/isatty_bsd.go
@@ -1,4 +1,4 @@
-// +build darwin freebsd openbsd netbsd
+// +build darwin freebsd openbsd netbsd dragonfly
 // +build !appengine
 
 package isatty


### PR DESCRIPTION
Dragonfly is a BSD, too.

Ran into this while building https://github.com/grafana/grafana on the latest version of Dragonfly. Adding `dragonfly` as a target resulted in successful compilation.