### PR TITLE
Add isCygwinTerminal to non-appengine environments

### DIFF
--- a/isatty_appengine.go
+++ b/isatty_appengine.go
@@ -7,3 +7,9 @@ package isatty
 func IsTerminal(fd uintptr) bool {
 	return false
 }
+
+// IsCygwinTerminal() return true if the file descriptor is a cygwin or msys2
+// terminal. This is also always false on this environment.
+func IsCygwinTerminal(fd uintptr) bool {
+	return false
+}

--- a/isatty_others.go
+++ b/isatty_others.go
@@ -1,4 +1,5 @@
-// +build !windows appengine
+// +build !windows
+// +build !appengine
 
 package isatty
 


### PR DESCRIPTION
Govendor common configurations exclude files tagged as test and appengine (see [readme](https://github.com/kardianos/govendor/blob/master/README.md#ignoring-build-tags-and-excluding-packages)).

As a result, pulling go-isatty as a vendored dependency with the common govendor config will currently exclude isatty_others.go.

This fix changes the tags to follow the pattern in other environment-specific files (exclude appengine) and implements IsCygwinTerminal in isatty_appengine.go.

See related [issue](https://github.com/fatih/color/issues/62).