### PR TITLE
Move example to show in godoc

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-package main
+package isatty_test
 
 import (
 	"fmt"
@@ -7,7 +7,7 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-func main() {
+func Example() {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		fmt.Println("Is Terminal")
 	} else if isatty.IsCygwinTerminal(os.Stdout.Fd()) {


### PR DESCRIPTION
Example code added in example_test.go following [convention documented in package `testing`](https://golang.org/pkg/testing/#hdr-Examples) (see also [this blog post](https://blog.golang.org/examples)).


Directory _example/ removed as redundant.