### PR TITLE
Update x/sys to support Risc-V

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mattn/go-isatty
 
-require golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223
+require golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223 h1:DH4skfRX4EBpamg7iV4ZlCpblAHI6s6TDM39bFZumv8=
-golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
+golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Updating projects using libraries that were recently updated to support Risc-V architecture.

Go upstream work is tracked on: golang/go#27532

Risc-V software support tracker on https://github.com/carlosedp/riscv-bringup

Signed-off-by: CarlosEDP <me@carlosedp.com>