### PR TITLE
Fix plan9 build

### DIFF
--- a/isatty_plan9.go
+++ b/isatty_plan9.go
@@ -8,7 +8,7 @@ import (
 
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd uintptr) bool {
-	path, err := syscall.Fd2path(fd)
+	path, err := syscall.Fd2path(int(fd))
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This fixes the build under plan9 - before this fix it was erroring with

```
$ GOOS=plan9 go build
# github.com/mattn/go-isatty
./isatty_plan9.go:11:30: cannot use fd (type uintptr) as type int in argument to syscall.Fd2path
```

Maybe we should add a compile all step to the travis tests?