### PR TITLE
Add gomodTidy to postUpdateOptions in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
This will lead to `go mod tidy` being run after go module updates to
purge unused verison hashes from go.sum

See https://docs.renovatebot.com/configuration-options/#postupdateoptions
for details.