### PR TITLE
Fix lack of zOS support #57

### DIFF
--- a/isatty_tcgets.go
+++ b/isatty_tcgets.go
@@ -1,4 +1,4 @@
-// +build linux aix
+// +build linux aix zos
 // +build !appengine
 
 package isatty


### PR DESCRIPTION
Since there is zos build tag on Go, by adding this tag this library will work on zOS.