### PR TITLE
Don't set termio in IsTerminal on solaris

### DIFF
--- a/isatty_solaris.go
+++ b/isatty_solaris.go
@@ -8,10 +8,9 @@ import (
 )
 
 // IsTerminal returns true if the given file descriptor is a terminal.
-// see: http://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libbc/libc/gen/common/isatty.c
+// see: https://src.illumos.org/source/xref/illumos-gate/usr/src/lib/libc/port/gen/isatty.c
 func IsTerminal(fd uintptr) bool {
-	var termio unix.Termio
-	err := unix.IoctlSetTermio(int(fd), unix.TCGETA, &termio)
+	_, err := unix.IoctlGetTermio(int(fd), unix.TCGETA)
 	return err == nil
 }
 


### PR DESCRIPTION
The current implementation of IsTerminal on solaris uses IoctlSetTermio
which will set a zero valued termio on the given FD. This might lead to
unexpected side effects. Instead, use IoctlGetTermio which will not
change the terminal settings.

Also adjust the reference to isatty in the Illumos source.