### PR TITLE
add //go:build lines

### DIFF
--- a/isatty_bsd.go
+++ b/isatty_bsd.go
@@ -1,3 +1,4 @@
+//go:build (darwin || freebsd || openbsd || netbsd || dragonfly) && !appengine
 // +build darwin freebsd openbsd netbsd dragonfly
 // +build !appengine
 

--- a/isatty_others.go
+++ b/isatty_others.go
@@ -1,3 +1,4 @@
+//go:build appengine || js || nacl || wasm
 // +build appengine js nacl wasm
 
 package isatty

--- a/isatty_others_test.go
+++ b/isatty_others_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package isatty

--- a/isatty_plan9.go
+++ b/isatty_plan9.go
@@ -1,3 +1,4 @@
+//go:build plan9
 // +build plan9
 
 package isatty

--- a/isatty_solaris.go
+++ b/isatty_solaris.go
@@ -1,5 +1,5 @@
-// +build solaris
-// +build !appengine
+//go:build solaris && !appengine
+// +build solaris,!appengine
 
 package isatty
 

--- a/isatty_tcgets.go
+++ b/isatty_tcgets.go
@@ -1,3 +1,4 @@
+//go:build (linux || aix || zos) && !appengine
 // +build linux aix zos
 // +build !appengine
 

--- a/isatty_windows.go
+++ b/isatty_windows.go
@@ -1,5 +1,5 @@
-// +build windows
-// +build !appengine
+//go:build windows && !appengine
+// +build windows,!appengine
 
 package isatty
 

--- a/isatty_windows_test.go
+++ b/isatty_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package isatty


### PR DESCRIPTION
I ran `go1.17rc fmt`
See https://tip.golang.org/doc/go1.17#gofmt for more details.

> gofmt (and go fmt) now synchronizes //go:build lines with // +build lines. If a file only has // +build lines, they will be moved to the appropriate location in the file, and matching //go:build lines will be added. Otherwise, // +build lines will be overwritten based on any existing //go:build lines. For more information, see https://golang.org/design/draft-gobuild.