### PR TITLE
Update go.sum after golang.org/x/sys update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-isatty
 
 go 1.12
 
-require golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+require golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
+golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
PR #66 updated the golang.org/x/sys dependency in go.mod but didn't
update go.sum. This leads to the following error on running go.test.sh:

    go: golang.org/x/sys@v0.0.0-20210630005230-0f9fa26af87c: missing go.sum entry; to add it:
    	go mod download golang.org/x/sys
    go: golang.org/x/sys@v0.0.0-20210630005230-0f9fa26af87c: missing go.sum entry; to add it:
    	go mod download golang.org/x/sys

Fix this by running go mod download golang.org/x/sys && go mod tidy to
update and clean up go.sum.