### PR TITLE
Adjust build tags to allow building on tinygo; for #73.

### DIFF
--- a/isatty_bsd.go
+++ b/isatty_bsd.go
@@ -1,6 +1,7 @@
-//go:build (darwin || freebsd || openbsd || netbsd || dragonfly || hurd) && !appengine
+//go:build (darwin || freebsd || openbsd || netbsd || dragonfly || hurd) && !appengine && !tinygo
 // +build darwin freebsd openbsd netbsd dragonfly hurd
 // +build !appengine
+// +build !tinygo
 
 package isatty
 

--- a/isatty_others.go
+++ b/isatty_others.go
@@ -1,5 +1,6 @@
-//go:build appengine || js || nacl || wasm
-// +build appengine js nacl wasm
+//go:build (appengine || js || nacl || tinygo || wasm) && !windows
+// +build appengine js nacl tinygo wasm
+// +build !windows
 
 package isatty
 

--- a/isatty_tcgets.go
+++ b/isatty_tcgets.go
@@ -1,6 +1,7 @@
-//go:build (linux || aix || zos) && !appengine
+//go:build (linux || aix || zos) && !appengine && !tinygo
 // +build linux aix zos
 // +build !appengine
+// +build !tinygo
 
 package isatty
 


### PR DESCRIPTION
Passes "tinygo test" on macos and linux.
Passes cross test to windows from macos, i.e. "GOOS=windows tinygo test -c; wine64 go-isatty.test".

Had to adjust the build tags on isatty_others.go to avoid multiple definition link failure on 
```
$ GOOS=windows tinygo test
```