### PR TITLE
Update golang.org/x/sys for Go 1.18 on M1 Macs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-isatty
 
 go 1.12
 
-require golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef
+require golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef h1:fPxZ3Umkct3LZ8gK9nbk+DWDJ9fstZa2grBn+lWVKPs=
-golang.org/x/sys v0.0.0-20211004093028-2c5d950f24ef/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
+golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This achieves the same goal as #71 and would fix #72. It will allow consumers to pick this up, in some cases, without adding an indirect dependency on a newer golang.org/x/sys.