### PR TITLE
deps: use a tagged version of golang.org/x/sys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
           - '1.18'
           - '1.19'
           - '1.17'
-          - '1.16'
-          - '1.15'
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-isatty
 
 go 1.15
 
-require golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab
+require golang.org/x/sys v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This ease to track dependency changes in downstream projects.

```console
$ go get golang.org/x/sys@latest && go mod tidy
```

`golang.org/x/sys@v0.0.0-20220811171246-fbc7d0a398ab` -> `golang.org/x/sys@v0.6.0`