### PR TITLE
Add mailmap to fix authorship inconsitencies

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Yasuhiro Matsumoto <mattn.jp@gmail.com>
+Carlos Eduardo <me@carlosedp.com>
+Dmitri Goutnik <dg@sysrec.org> <5332688+dmgk@users.noreply.github.com>
+Luis Gonzalez-Silen <luis@helloeave.com>
+Renovate Bot <renovate@whitesourcesoftware.com> renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>
+Stuart Nelson <stuartnelson3@gmail.com>


### PR DESCRIPTION
Cleanup output of `git shortlog -s -e` by fixing inconsistencies in authors Git configuration via a `.mailmap` file.