### PR TITLE
Update golang.org/x/sys dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mattn/go-isatty
 
 go 1.15
 
-require golang.org/x/sys v0.6.0
+require golang.org/x/sys v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=


### PR DESCRIPTION
To reduce binary sizes. There is also a lot of stuff fixed since 0.6.0 was out - https://go.googlesource.com/sys/+log
```
go get -u all
go mod tidy
```
Fixes https://github.com/mattn/go-isatty/issues/52.