### PR TITLE
Add IsWriterTerminal and IsWriterCygwinTerminal functions (fixes #80)

### DIFF
--- a/isatty_others_test.go
+++ b/isatty_others_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTerminal(t *testing.T) {
 	// test for non-panic
-	IsTerminal(os.Stdout.Fd())
+	t.Log("os.Stdout:", IsTerminal(os.Stdout.Fd()))
 }
 
 func TestCygwinPipeName(t *testing.T) {

--- a/writer.go
+++ b/writer.go
@@ -1,0 +1,23 @@
+package isatty
+
+import "io"
+
+// IsWriterTerminal return true if the writer is terminal.
+func IsWriterTerminal(w io.Writer) bool {
+	if f, ok := w.(filelike); ok {
+		return IsTerminal(f.Fd())
+	}
+	return false
+}
+
+// IsWriterCygwinTerminal return true if the writer is a cygwin or msys2 terminal.
+func IsWriterCygwinTerminal(w io.Writer) bool {
+	if f, ok := w.(filelike); ok {
+		return IsCygwinTerminal(f.Fd())
+	}
+	return false
+}
+
+type filelike interface {
+	Fd() uintptr
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,0 +1,18 @@
+package isatty_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mattn/go-isatty"
+)
+
+func TestIsWriterTerminal(t *testing.T) {
+	// test for non-panic
+	isatty.IsWriterTerminal(os.Stdout)
+}
+
+func TestIsWriterCygwinTerminal(t *testing.T) {
+	// test for non-panic
+	isatty.IsWriterCygwinTerminal(os.Stdout)
+}

--- a/writer_test.go
+++ b/writer_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestIsWriterTerminal(t *testing.T) {
 	// test for non-panic
-	isatty.IsWriterTerminal(os.Stdout)
+	t.Log("os.Stdout:", isatty.IsWriterTerminal(os.Stdout))
 }
 
 func TestIsWriterCygwinTerminal(t *testing.T) {
 	// test for non-panic
-	isatty.IsWriterCygwinTerminal(os.Stdout)
+	t.Log("os.Stdout:", isatty.IsWriterCygwinTerminal(os.Stdout))
 }


### PR DESCRIPTION
## Summary

Add support for `io.Writer` in addition to `io.Reader` (as suggested in https://github.com/mattn/go-isatty/pull/81#issuecomment-1469602717).

Also fixes filename typo: `writter.go` -> `writer.go` (per reviewer feedback in original PR).

## Changes

- `writer.go`: New file with `IsWriterTerminal` and `IsWriterCygwinTerminal` functions
- `writer_test.go`: Corresponding tests

## References

- Fixes #80
- Supersedes original PR #81 (cardil:feature/check-writer) which had filename typo